### PR TITLE
Fix crash when list is nil

### DIFF
--- a/mods/BeardLib/Classes/MenuUI.lua
+++ b/mods/BeardLib/Classes/MenuUI.lua
@@ -82,7 +82,11 @@ function MenuUI:disable()
 	self._menu_closed = true
 	self._highlighted = nil
 	if self._openlist then
-	 	self._openlist.list:hide()
+		if self._openlist.list then
+			self._openlist.list:hide()
+		else
+			self._openlist:hide()
+		end
 	 	self._openlist = nil
 	end
 	managers.mouse_pointer:remove_mouse(self._mouse_id)


### PR DESCRIPTION
In dev branch

I noticed this using the dev branch version of HoloUI. If you tried to close the menu using the toggle key while having a list open the game would crash. So I'm not sure if this is the correct fix but it does fix the issue.