### PR TITLE
Fix crash-on-startup bug when started in VR

### DIFF
--- a/mods/BeardLib/Config.xml
+++ b/mods/BeardLib/Config.xml
@@ -91,6 +91,7 @@
         <hook source="lib/network/base/networkpeer" file="NetworkPeer.lua"/>
         <hook source="lib/managers/musicmanager" file="MusicManager.lua"/>
 		<hook source="lib/managers/menumanager" file="MenuManager.lua"/>
+		<hook source="lib/managers/menumanagervr" file="MenuManagerVR.lua"/>
         <hook source="lib/tweak_data/tweakdata" file="TweakData.lua"/>
 		<hook source="core/lib/system/coresystem" file="CoreSystem.lua"/>
 		<hook source="lib/managers/menu/menuinput" file="MenuInput.lua"/>

--- a/mods/BeardLib/Hooks/CoreWorldDefinition.lua
+++ b/mods/BeardLib/Hooks/CoreWorldDefinition.lua
@@ -6,8 +6,10 @@ core:module("CoreWorldDefinition")
 WorldDefinition = WorldDefinition or CoreWorldDefinition.WorldDefinition
 
 local WorldDefinition_init = WorldDefinition.init
-function WorldDefinition:init(...)
-    WorldDefinition_init(self, ...)
+function WorldDefinition:init(params, ...)
+    self.__bl_vr_main_menu = params.__bl_vr_main_menu
+
+    WorldDefinition_init(self, params, ...)
     if self._ignore_spawn_list then
         self._ignore_spawn_list[Idstring("units/dev_tools/level_tools/ai_coverpoint"):key()] = true
     end
@@ -15,6 +17,12 @@ end
 
 local WorldDefinition_load_world_package = WorldDefinition._load_world_package
 function WorldDefinition:_load_world_package(...)
+    if self.__bl_vr_main_menu then
+        -- Global._level_data isn't set when loading the main VR menu
+        -- And causes all kinds of chaos
+        WorldDefinition_load_world_package(self, ...)
+        return
+    end
     local level_tweak = _G.tweak_data.levels[Global.level_data.level_id]
     self._has_package = not not level_tweak.package
     if level_tweak.custom_packages then

--- a/mods/BeardLib/Hooks/MenuManagerVR.lua
+++ b/mods/BeardLib/Hooks/MenuManagerVR.lua
@@ -1,0 +1,17 @@
+
+-- When we load the VR menu, lay down a flag we can use later
+-- to distinguish this from a normal level
+function MenuManagerVR:_load_scene()
+	self._menu_unit = World:spawn_unit(Idstring("units/pd2_dlc_vr/menu/vr_menu"), Vector3(), Rotation())
+
+	self._menu_unit:set_visible(false)
+
+	local level_path = "levels/vr/menu"
+	local t = {
+		file_type = "world",
+		file_path = level_path .. "/world",
+		__bl_vr_main_menu = true
+	}
+
+	assert(WorldHolder:new(t):create_world("world", "statics", Vector3()), "Cant load the level!")
+end

--- a/mods/BeardLib/mod.txt
+++ b/mods/BeardLib/mod.txt
@@ -22,6 +22,7 @@
 		{ "hook_id" : "lib/managers/killzonemanager", "script_path" : "BeardLibCore.lua"},
 		{ "hook_id" : "lib/managers/missionmanager", "script_path" : "BeardLibCore.lua"},
 		{ "hook_id" : "lib/managers/menumanager", "script_path" : "BeardLibCore.lua"},
+		{ "hook_id" : "lib/managers/menumanagervr", "script_path" : "BeardLibCore.lua"},
 		{ "hook_id" : "lib/managers/crimenetmanager", "script_path" : "BeardLibCore.lua"},
 		{ "hook_id" : "lib/managers/jobmanager", "script_path" : "BeardLibCore.lua"},
         { "hook_id" : "lib/managers/achievmentmanager", "script_path" : "BeardLibCore.lua"},


### PR DESCRIPTION
The VR Beta uses a custom world for the lobby area, which breaks BeardLib as it tries to find what level it's from to load custom packages. This PR passes through an extra flag as a warning not to try to do this.