### PR TITLE
Removes hidden, useless, and unauthorized data collection and analytics from BeardLib

### DIFF
--- a/mods/BeardLib/Classes/Utils.lua
+++ b/mods/BeardLib/Classes/Utils.lua
@@ -332,7 +332,7 @@ function BeardLib.Utils:CheckParamValidty(func_name, vari, var, desired_type, al
 end
 
 function BeardLib.Utils:DownloadMap(level_name, id, done_callback)
-    local lookup_tbl = {id = tostring(id), steamid = Steam:userid()}
+    local lookup_tbl = {id = tostring(id)}
     local function done_map_download()
         BeardLib.managers.MapFramework:Load()
         BeardLib.managers.MapFramework:RegisterHooks()

--- a/mods/BeardLib/Modules/ModAssetsModule.lua
+++ b/mods/BeardLib/Modules/ModAssetsModule.lua
@@ -3,9 +3,9 @@ ModAssetsModule.type_name = "AssetUpdates"
 ModAssetsModule._default_version_file = "version.txt"
 ModAssetsModule._providers = {
     modworkshop = {
-        check_url = "https://api.modwork.shop/api.php?command=CompareVersion&did=$id$&vid=$version$&steamid=$steamid$&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
-        get_files_url = "https://api.modwork.shop/api.php?command=AssocFiles&did=$id$&steamid=$steamid$&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
-        download_url = "https://api.modwork.shop/api.php?command=DownloadFile&fid=$fid$&steamid=$steamid$&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
+        check_url = "https://api.modwork.shop/api.php?command=CompareVersion&did=$id$&vid=$version$&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
+        get_files_url = "https://api.modwork.shop/api.php?command=AssocFiles&did=$id$&&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
+        download_url = "https://api.modwork.shop/api.php?command=DownloadFile&fid=$fid$&token=Je3KeUETqqym6V8b5T7nFdudz74yWXgU",
         page_url = "https://modwork.shop/$id$",
         check_func = function(self)
             local id = tonumber(self.id)
@@ -40,7 +40,7 @@ ModAssetsModule._providers = {
             dohttpreq(get_files_url, function(data, id)
                 local fid = string.split(data, '"')[1]
                 if fid then
-                    self:_DownloadAssets({fid = fid, steamid = self.steamid})
+                    self:_DownloadAssets({fid = fid})
                     Global.beardlib_checked_updates[self.id] = nil --check again later for hotfixes.
                 end    
             end)
@@ -55,7 +55,6 @@ function ModAssetsModule:init(core_mod, config)
         return false
     end
 
-    self.steamid = Steam:userid()
     self.id = self._config.id
 
     if self._config.provider then


### PR DESCRIPTION
The Restoration Mod team was trying to fix a beardlib issue when we discovered this pretty serious privacy violation. You do not need a user's steam ID to download updates.

The only possible purpose for harvesting steamIDs without consent or informing the consumer is for:

1. **Tracking** what people download(kinda creepy)
2. Framework to **blacklist** updates from certain people(fucking atrocious)
3. **Selling personal data** about mod usage to **advertisers**(equally fucking atrocious)

All of this is done **without informing the user** or telling them their information is harvested in this way.

If you're going to raise a stink about mod privacy to the point of ignoring direct requests from OVK, don't compromise the privacy of your users.

Fixes #123