### PR TITLE
Add support for alternative source tracks

### DIFF
--- a/mods/BeardLib/Modules/HeistMusicModule.lua
+++ b/mods/BeardLib/Modules/HeistMusicModule.lua
@@ -45,12 +45,16 @@ function HeistMusic:RegisterHook()
 			if v.start_source then
 				v.start_source = Path:Combine(dir, v.start_source)
 			end
+			if v.alt_source then
+				v.alt_source = Path:Combine(dir, v.alt_source)
+				v.alt_chance = v.alt_chance and tonumber(v.alt_chance) or 0.1
+			end
 			if v.source then
 				v.source = Path:Combine(dir, v.source)
 			else
 				self:log("[Warning] Event named %s in heist music %s has no defined source", tostring(self._config.id), tostring(v.name))
 			end
-			music.events[v.name] = {source = self:MakeBuffer(v.source), start_source = self:MakeBuffer(v.start_source)}
+			music.events[v.name] = {source = self:MakeBuffer(v.source), start_source = self:MakeBuffer(v.start_source), alt_source = self:MakeBuffer(v.alt_source), alt_chance = v.alt_chance}
 		end
 	end
 

--- a/mods/BeardLib/Modules/MusicModule.lua
+++ b/mods/BeardLib/Modules/MusicModule.lua
@@ -28,13 +28,17 @@ function MusicModule:RegisterHook()
 			if v.start_source then
 				v.start_source = dir .. v.start_source
 			end
+			if v.alt_source then
+				v.alt_source = Path:Combine(dir, v.alt_source)
+				v.alt_chance = v.alt_chance and tonumber(v.alt_chance) or 0.1
+			end
 			if v.source then
 				v.source = dir .. v.source
 			else
 				self:log("[ERROR] Music with the id '%s' has an event that has no source!", self._config.id)
 				return
 			end
-			music.events[v.name] = {source = v.source, start_source = v.start_source}
+			music.events[v.name] = {source = v.source, start_source = v.start_source, alt_source = v.alt_source, alt_chance = v.alt_chance}
 		end
 	end
 


### PR DESCRIPTION
Enables creators to make heist tracks with chance based source selection,
similar to "Ode to Greed" and "Break the Rules" by defining alt_source and
(optionally) alt_chance properties in the xml.