### PR TITLE
Add support for using Windows custom maps on Linux (when using SuperBLT)

### DIFF
--- a/mods/BeardLib/Classes/Utils/FileIO.lua
+++ b/mods/BeardLib/Classes/Utils/FileIO.lua
@@ -61,6 +61,18 @@ function FileIO:ConvertScriptData(data, typ, clean)
     elseif typ == "generic_xml" then
         new_data = ScriptSerializer:from_generic_xml(data)
     elseif typ == "binary" then
+        if blt and blt.scriptdata then
+            local info = blt.scriptdata.identify(data)
+            local sys32bit = blt.blt_info().arch == "x86"
+
+            -- If we're trying to load a 32-bit encoded file on a 64-bit encoded platform or vice-versa, convert it
+            if info.is32bit ~= sys32bit then
+                data = blt.scriptdata.recode(data, {
+                    is32bit = sys32bit,
+                })
+            end
+        end
+
         new_data = ScriptSerializer:from_binary(data)
     end
     return clean and BeardLib.Utils.XML:Clean(new_data) or new_data


### PR DESCRIPTION
This uses the [brand-new SuperBLT scriptdata API](https://gitlab.com/znixian/payday2-superblt/commit/d84a511376069170aca0105797ab16fb2495d6c1) to convert binary-encoded script data from the 32-bit format (used on Windows) to the 64-bit format (used on Linux).

This enables the use of custom heists on Linux.