### PR TITLE
Use the SuperBLT asset manager when available, improving Linux asset support

### DIFF
--- a/mods/BeardLib/Classes/FileManager.lua
+++ b/mods/BeardLib/Classes/FileManager.lua
@@ -93,7 +93,11 @@ function fm:AddFile(ext, path, file)
 	path = path:id()
 	local k_ext = ext:key()
 	local loaded
-    DB:create_entry(ext, path, file)
+	if BLT.AssetManager then
+		BLT.AssetManager:CreateEntry(path, ext, file)
+	else
+		DB:create_entry(ext, path, file)
+	end
     Global.fm.added_files[k_ext] = Global.fm.added_files[k_ext] or {}
 	Global.fm.added_files[k_ext][path:key()] = file
 	if k_ext == texture_key then


### PR DESCRIPTION
On the very latest (Git) versions of SuperBLT, there's support for in-memory conversion of some 32-bit assets into 64-bit assets, however to enable this a new API must be used.

This currently supports the automatic conversion of `sequence_manager` and `font` files, allowing many more custom heists to be used on Linux.