### PR TITLE
Moved base "mods" global value and dlc creation to their own hook…

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -78,8 +78,6 @@ function BeardLib:Init()
 
 	self._classes_to_init = nil
 
-	self:RegisterTweak()
-
 	Hooks:Call("BeardLibPostInit")
 end
 
@@ -194,27 +192,6 @@ function BeardLib:RegisterModule(key, module)
 		self:DevLog("Registered module with key %s", key)
 		self.Modules[key] = module
 	end
-end
-
-function BeardLib:RegisterTweak()
-	TweakDataHelper:ModifyTweak({
-		name_id = "bm_global_value_mod",
-		desc_id = "menu_l_global_value_mod",
-		color = Color(255, 59, 174, 254) / 255,
-		dlc = false,
-		chance = 1,
-		value_multiplier = 1,
-		durability_multiplier = 1,
-		track = false,
-		sort_number = -10,
-	}, "lootdrop", "global_values", "mod")
-
-	TweakDataHelper:ModifyTweak({"mod"}, "lootdrop", "global_value_list_index")
-
-	TweakDataHelper:ModifyTweak({
-		free = true,
-		content = {loot_drops = {}, upgrades = {}}
-	}, "dlc", "mod")
 end
 
 function BeardLib:Update(t, dt)

--- a/Hooks/OtherHooks.lua
+++ b/Hooks/OtherHooks.lua
@@ -191,4 +191,25 @@ elseif F == "newraycastweaponbase" then
 			return started_reload_empty(self, ...)
 		end
 	end
+elseif F == "dlctweakdata" then
+	Hooks:PostHook(DLCTweakData, "init", "BeardLibModDLCGlobalValue", function(self, tweak_data)
+		tweak_data.lootdrop.global_values.mod = {
+			name_id = "bm_global_value_mod",
+			desc_id = "menu_l_global_value_mod",
+			color = Color(255, 59, 174, 254) / 255,
+			dlc = false,
+			chance = 1,
+			value_multiplier = 1,
+			durability_multiplier = 1,
+			track = false,
+			sort_number = -10
+		}
+
+		table.insert(tweak_data.lootdrop.global_value_list_index, "mod")
+
+		self.mod = {
+			free = true,
+			content = {loot_drops = {}, upgrades = {}}
+		}
+	end)
 end

--- a/main.xml
+++ b/main.xml
@@ -73,6 +73,8 @@
 
 			<hook source_file="lib/units/beings/player/states/playerstandard" file="OtherHooks.lua"/>
 
+			<hook source_file="lib/tweak_data/dlctweakdata" file="OtherHooks.lua"/>
+
 			<hook source_file="lib/managers/musicmanager" file="MusicManager.lua"/>
 
 			<hooks directory="Network">


### PR DESCRIPTION
…so that they get defined early enough for the newer sorting stuff to be able to use them. Otherwise the new sort methods crash when trying to use the "mods" global value.