### PR TITLE
Check before setting npc weapon data

### DIFF
--- a/Modules/Addons/WeaponModule.lua
+++ b/Modules/Addons/WeaponModule.lua
@@ -121,7 +121,9 @@ function WeaponModule:RegisterHook()
         w_self[config.id .. "_crew"] = table.merge(deep_clone(w_self[self:GetCrewBasedOn(w_self)]), table.merge({custom = true}, config.crew))
         -- Assign NPC variant to be the same as crew if there's any code that relies on the NPC table.
         -- tbh I'm not sure at this point if this will work the weapon code in this game is absolute mess.
-        w_self[config.id .. "_npc"] = w_self[config.id .. "_crew"]
+        if not w_self[config.id .. "_npc"] then
+          w_self[config.id .. "_npc"] = w_self[config.id .. "_crew"]
+        end
     end)
 
     Hooks:PostHook(TweakDataVR , "init", self._config.weapon.id .. "AddVRWeaponTweakData", function(vrself)


### PR DESCRIPTION
For some reason, npc data for custom weapons is created (Not sure why, since NPCs would not use the weapon) and in very specific cases (namely this mod https://modworkshop.net/mod/17330) it will override existing npc weapon data which can cause hard to track problems down the line.