### PR TITLE
Fix Hardcoded element Width in Achievements List

### DIFF
--- a/Classes/UI/AchievementMenu.lua
+++ b/Classes/UI/AchievementMenu.lua
@@ -287,7 +287,7 @@ function BeardLibAchievementMenu:DisplayAchievementsFromPackage(package)
 
 		local achievement_button = panel:Button({
 			h = 48,
-			w = 442,
+			w = panel:Panel():w() - 48 - (default_margin * 3),
 			text = false,
 			on_callback = ClassClbk(self, "DisplayAchievementDetails", achievement)
 		})


### PR DESCRIPTION
Makes the width of the achievement Button in the achievement List adapt to the panel width, instead of having a hardcoded value. The GridMenu's wrapping behaviour otherwise would put all the icons of the 2nd row and following rows after the previous row. Now, the elements always fill the whole row, thus the wrapping works correctly.

Fixes #381.