### PR TITLE
Fix _current_dialog Crash

### DIFF
--- a/Hooks/Fixes.lua
+++ b/Hooks/Fixes.lua
@@ -465,6 +465,10 @@ elseif F == "dialogmanager" then
 			end
 		end
     end)
+    --fixes the '_current_dialog' (a nil value) crash
+    Hooks:PreHook(DialogManager, "finished", "BeardLibFinishedDialogFix", function(self)
+        self._current_dialog = {}
+    end)
 elseif F == "networkpeer" then
     local tradable_item_verif = NetworkPeer.tradable_verify_outfit
     function NetworkPeer:tradable_verify_outfit(signature)


### PR DESCRIPTION
Fixes the "[string "lib/managers/dialogmanager.lua"]:115: attempt to index field '_current_dialog' (a nil value)" crash caused by custom audio being killed via heist ending and Force Quit Current in the dialogue element.