### PR TITLE
Music module improvements

### DIFF
--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -263,12 +263,12 @@ function MusicManager:custom_update(t, dt, paused)
 		if (self._xa_source and self._xa_source:is_closed()) or (gui_ply and gui_ply:current_frame() >= gui_ply:frames()) then
 			local switch = self._switch_at_end
 			local source = switch.tracks[switch.track_index].source
-			self:play(source, switch.xaudio, switch.volume)
 			if switch.allow_switch then
 				switch.track_index = self:pick_track_index(switch.tracks)
 			else
 				self._switch_at_end = nil
 			end
+			self:play(source, switch.xaudio, switch.volume)
 		end
 	end
 end

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -168,11 +168,13 @@ function MusicManager:attempt_play(track, event, stop)
 				self._current_custom_track = id
 			end
 			if music.events and event then
-				local event_tbl = music.events[string.split(event, "_")[3]]
-				if event_tbl then
-					next_music = music
-					next_event = event_tbl
-					self._current_custom_track = id
+				-- Try finding the right event to play
+				for modded_event, event_tbl in pairs(music.events) do
+					if event == modded_event or event.ends(modded_event) then
+						next_music = music
+						next_event = event_tbl
+						self._current_custom_track = id
+					end
 				end
 			end
 		end

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -166,7 +166,7 @@ function MusicManager:attempt_play(track, event, stop)
 			if music.events and event then
 				-- Try finding the right event to play
 				for modded_event, event_tbl in pairs(music.events) do
-					if event == modded_event or event.ends(modded_event) then
+					if event == modded_event or event:ends(modded_event) then
 						next_music = music
 						next_event = event_tbl
 						self._current_custom_track = id

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -124,6 +124,26 @@ function MusicManager:track_listen_stop(...)
 	end
 end
 
+function MusicManager:pick_track_index(tracks)
+	if not tracks then
+		return 0
+	end
+	if #tracks <= 1 then
+		return 1
+	end
+	local total_w = 0
+	for _,v in pairs(tracks) do
+		total_w = total_w + (v.weight or 1)
+	end
+	local roll = math.random(total_w)
+	local index = 0
+	while roll > 0 do
+		index = index + 1
+		roll = roll - tracks[index].weight
+	end
+	return index
+end
+
 local movie_ids = Idstring("movie")
 function MusicManager:attempt_play(track, event, stop)
 	if event == "music_uno_fade_reset" then
@@ -142,30 +162,29 @@ function MusicManager:attempt_play(track, event, stop)
 			break
 		end
 		if event == id or track == id or self._current_custom_track == id then
-			if music.source and (self._current_custom_track ~= id or id == event) then
+			if music.preview_event and (self._current_custom_track ~= id or id == event) then
 				next_music = music
+				next_event = music.events[music.preview_event]
 				self._current_custom_track = id
 			end
 			if music.events and event then
-				-- Try finding the right event to play
-				for modded_event, event_tbl in pairs(music.events) do
-					if event == modded_event or event.ends(modded_event) then
-						next_music = music
-						next_event = event_tbl
-						self._current_custom_track = id
-					end
+				local event_tbl = music.events[string.split(event, "_")[3]]
+				if event_tbl then
+					next_music = music
+					next_event = event_tbl
+					self._current_custom_track = id
 				end
 			end
 		end
 	end
-
 	if next_music then
 		local next = next_event or next_music
-		local use_alt_source = next.alt_source and math.random() < next.alt_chance
-		local source = use_alt_source and (next.alt_start_source or next.start_source or next.alt_source) or next.start_source or next.source
+		local track_index = self:pick_track_index(next.tracks)
+		local source = next.tracks and (next.tracks[track_index].start_source or next.tracks[track_index].source)
 		if next_music.xaudio then
 			if not source then
 				BeardLib:Err("No buffer found to play for music '%s'", tostring(self._current_custom_track))
+				return
 			end
 		else
 			if not source or not DB:has(movie_ids, source:id()) then
@@ -174,10 +193,10 @@ function MusicManager:attempt_play(track, event, stop)
 			end
 		end
 		local volume = next.volume or next_music.volume
-		self._switch_at_end = (next.start_source or next.alt_source) and {
-			source = (next.allow_switch or not use_alt_source) and next.source or next.alt_source,
-			alt_source = next.allow_switch and next.alt_source,
-			alt_chance = next.allow_switch and next.alt_chance,
+		self._switch_at_end = (next.tracks[track_index].start_source or next.allow_switch) and {
+			tracks = next.tracks,
+			track_index = next.tracks[track_index].start_source and track_index or self:pick_track_index(next.tracks),
+			allow_switch = next.allow_switch,
 			xaudio = next_music.xaudio,
 			volume = volume
 		}
@@ -244,9 +263,13 @@ function MusicManager:custom_update(t, dt, paused)
 	elseif self._switch_at_end then
 		if (self._xa_source and self._xa_source:is_closed()) or (gui_ply and gui_ply:current_frame() >= gui_ply:frames()) then
 			local switch = self._switch_at_end
-			self._switch_at_end = switch.alt_source and switch or nil
-			local source = switch.alt_source and math.random() < switch.alt_chance and switch.alt_source or switch.source
+			local source = switch.tracks[switch.track_index].source
 			self:play(source, switch.xaudio, switch.volume)
+			if switch.allow_switch then
+				switch.track_index = self:pick_track_index(switch.tracks)
+			else
+				self._switch_at_end = nil
+			end
 		end
 	end
 end

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -125,10 +125,7 @@ function MusicManager:track_listen_stop(...)
 end
 
 function MusicManager:pick_track_index(tracks)
-	if not tracks then
-		return 0
-	end
-	if #tracks <= 1 then
+	if not tracks or #tracks <= 1 then
 		return 1
 	end
 	local total_w = 0
@@ -139,7 +136,7 @@ function MusicManager:pick_track_index(tracks)
 	local index = 0
 	while roll > 0 do
 		index = index + 1
-		roll = roll - tracks[index].weight
+		roll = roll - (tracks[index].weight or 1)
 	end
 	return index
 end
@@ -181,7 +178,8 @@ function MusicManager:attempt_play(track, event, stop)
 	if next_music then
 		local next = next_event or next_music
 		local track_index = self:pick_track_index(next.tracks)
-		local source = next.tracks and (next.tracks[track_index].start_source or next.tracks[track_index].source)
+		local next_track = next.tracks and next.tracks[track_index]
+		local source = next_track and (next_track.start_source or next_track.source)
 		if next_music.xaudio then
 			if not source then
 				BeardLib:Err("No buffer found to play for music '%s'", tostring(self._current_custom_track))
@@ -194,9 +192,9 @@ function MusicManager:attempt_play(track, event, stop)
 			end
 		end
 		local volume = next.volume or next_music.volume
-		self._switch_at_end = (next.tracks[track_index].start_source or next.allow_switch) and {
+		self._switch_at_end = (next_track.start_source or next.allow_switch) and {
 			tracks = next.tracks,
-			track_index = next.tracks[track_index].start_source and track_index or self:pick_track_index(next.tracks),
+			track_index = next_track.start_source and track_index or self:pick_track_index(next.tracks),
 			allow_switch = next.allow_switch,
 			xaudio = next_music.xaudio,
 			volume = volume

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -162,9 +162,8 @@ function MusicManager:attempt_play(track, event, stop)
 			break
 		end
 		if event == id or track == id or self._current_custom_track == id then
-			if music.preview_event and (self._current_custom_track ~= id or id == event) then
+			if music.tracks and (self._current_custom_track ~= id or id == event) then
 				next_music = music
-				next_event = music.events[music.preview_event]
 				self._current_custom_track = id
 			end
 			if music.events and event then

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -112,7 +112,8 @@ function HeistMusic:RegisterHook()
 		end
 	end
 
-	music.preview_event = self._config.preview_event or (self.is_stealth and "suspense_4" or "assault")
+	local event = music.events[self._config.preview_event or (self.is_stealth and "suspense_4" or "assault")]
+	music.tracks = event and event.tracks
 
 	BeardLib.MusicMods[self._config.id] = music
 end

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -5,10 +5,10 @@ StealthMusic.is_stealth = true
 function HeistMusic:LoadBuffers()
 	for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
 		for _, track in pairs(event.tracks) do
-			if type(track.start_source) == "table" and track.start_source.module then
+			if track.start_source and track.start_source.module then
 					track.start_source.buffer = XAudio.Buffer:new(track.start_source.path)
 			end
-			if type(track.source) == "table" and track.source.module then
+			if track.source and track.source.module then
 				track.source.buffer = XAudio.Buffer:new(track.source.path)
 			end
 		end
@@ -18,13 +18,13 @@ end
 function HeistMusic:UnloadBuffers()
 	for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
 		for _, track in pairs(event.tracks) do
-			if type(track.start_source) == "table" and track.start_source.module then
+			if track.start_source and track.start_source.module then
 					if track.start_source.buffer then
 						track.start_source.buffer:close(true)
 					end
 					track.start_source.buffer = nil
 			end
-			if type(track.source) == "table" and track.source.module then
+			if track.source and track.source.module then
 				if track.source.buffer then
 					track.source.buffer:close(true)
 				end
@@ -73,10 +73,10 @@ function HeistMusic:RegisterHook()
 			for _,t in ipairs(v) do
 				if type(t) == "table" and t._meta == "track" then
 					table.insert(tracks, {
-						start_source = t.start_source and self:MakeBuffer(Path:Combine(dir, t.start_source)),
-						source = t.source and self:MakeBuffer(Path:Combine(dir, t.source)),
-						weight = t.weight or 1,
-						volume = t.volume or music.volume
+						start_source = (t.start_source or v.start_source) and self:MakeBuffer(Path:Combine(dir, (t.start_source or v.start_source))),
+						source = (t.source or v.source) and self:MakeBuffer(Path:Combine(dir, (t.source or v.source))),
+						weight = t.weight or v.weight or 1,
+						volume = t.volume or v.volume or music.volume
 					})
 					log(tostring(tracks[#tracks].source))
 				end
@@ -91,7 +91,7 @@ function HeistMusic:RegisterHook()
 				})
 				if v.alt_source then -- backwards compat for old alternate track system
 					table.insert(tracks, {
-						start_source = v.alt_start_source and self:MakeBuffer(Path:Combine(dir, v.alt_start_source)),
+						start_source = (v.alt_start_source or v.start_source) and self:MakeBuffer(Path:Combine(dir, (v.alt_start_source or v.start_source))),
 						source = v.alt_source and self:MakeBuffer(Path:Combine(dir, v.alt_source)),
 						weight = v.alt_chance and v.alt_chance * 100 or 1,
 						volume = v.volume or music.volume

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -78,7 +78,6 @@ function HeistMusic:RegisterHook()
 						weight = t.weight or v.weight or 1,
 						volume = t.volume or v.volume or music.volume
 					})
-					log(tostring(tracks[#tracks].source))
 				end
 			end
 			-- Track handling as part of event tag

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -3,24 +3,33 @@ StealthMusic = StealthMusic or BeardLib:ModuleClass("StealthMusic", HeistMusic)
 StealthMusic.is_stealth = true
 
 function HeistMusic:LoadBuffers()
-    for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
-        for _, source in pairs(event) do
-            if type(source) == "table" and source.module then
-                source.buffer = XAudio.Buffer:new(source.path)
-            end
-        end
+	for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
+		for _, track in pairs(event.tracks) do
+			if type(track.start_source) == "table" and track.start_source.module then
+					track.start_source.buffer = XAudio.Buffer:new(track.start_source.path)
+			end
+			if type(track.source) == "table" and track.source.module then
+				track.source.buffer = XAudio.Buffer:new(track.source.path)
+			end
+		end
 	end
 end
 
 function HeistMusic:UnloadBuffers()
-    for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
-        for _, source in pairs(event) do
-            if type(source) == "table" and source.module then
-                if source.buffer then
-                    source.buffer:close(true)
-                end
-                source.buffer = nil
-            end
+	for _, event in pairs(BeardLib.MusicMods[self._config.id].events) do
+		for _, track in pairs(event.tracks) do
+			if type(track.start_source) == "table" and track.start_source.module then
+					if track.start_source.buffer then
+						track.start_source.buffer:close(true)
+					end
+					track.start_source.buffer = nil
+			end
+			if type(track.source) == "table" and track.source.module then
+				if track.source.buffer then
+					track.source.buffer:close(true)
+				end
+				track.source.buffer = nil
+			end
 		end
 	end
 end
@@ -49,7 +58,6 @@ function HeistMusic:RegisterHook()
 	end
 
 	local dir = self._config.directory
-
 	if dir then
 		dir = Path:Combine(self._mod.ModPath, dir)
 	else
@@ -60,39 +68,52 @@ function HeistMusic:RegisterHook()
 
 	for k,v in ipairs(self._config) do
 		if type(v) == "table" and v._meta == "event" then
-			if v.start_source then
-				v.start_source = Path:Combine(dir, v.start_source)
+			local tracks = {}
+			-- Track handling as part of child track tags
+			for _,t in ipairs(v) do
+				if type(t) == "table" and t._meta == "track" then
+					table.insert(tracks, {
+						start_source = t.start_source and self:MakeBuffer(Path:Combine(dir, t.start_source)),
+						source = t.source and self:MakeBuffer(Path:Combine(dir, t.source)),
+						weight = t.weight or 1,
+						volume = t.volume or music.volume
+					})
+					log(tostring(tracks[#tracks].source))
+				end
 			end
-			if v.alt_source then
-				v.alt_source = Path:Combine(dir, v.alt_source)
-				v.alt_start_source = v.alt_start_source and Path:Combine(dir, v.alt_start_source)
-				v.alt_chance = v.alt_chance and tonumber(v.alt_chance) or 0.1
-				v.allow_switch = NotNil(v.allow_switch, true)
+			-- Track handling as part of event tag
+			if #tracks == 0 then
+				self:log("Old loading of %s %s", tostring(self._config.id), tostring(v.name))
+				table.insert(tracks, {
+					start_source = v.start_source and self:MakeBuffer(Path:Combine(dir, v.start_source)),
+					source = v.source and self:MakeBuffer(Path:Combine(dir, v.source)),
+					weight = v.alt_chance and (1 - v.alt_chance) * 100 or 1,
+					volume = v.volume or music.volume
+				})
+				if v.alt_source then -- backwards compat for old alternate track system
+					table.insert(tracks, {
+						start_source = v.alt_start_source and self:MakeBuffer(Path:Combine(dir, v.alt_start_source)),
+						source = v.alt_source and self:MakeBuffer(Path:Combine(dir, v.alt_source)),
+						weight = v.alt_chance and v.alt_chance * 100 or 1,
+						volume = v.volume or music.volume
+					})
+				end
 			end
-			if v.source then
-				v.source = Path:Combine(dir, v.source)
-			elseif not v.start_source then
-				self:log("[Warning] Event named %s in heist music %s has no defined source", tostring(self._config.id), tostring(v.name))
+			for i,t in ipairs(tracks) do
+				if not t.start_source and not t.source then
+					self:err("Event named %s in heist music %s has no defined source for track %i", tostring(self._config.id), tostring(v.name), i)
+					return
+				end
 			end
 			music.events[v.name] = {
-				source = self:MakeBuffer(v.source),
-				start_source = self:MakeBuffer(v.start_source),
-				alt_source = self:MakeBuffer(v.alt_source),
-				alt_start_source = self:MakeBuffer(v.alt_start_source),
-				alt_chance = v.alt_chance,
+				tracks = tracks,
 				volume = v.volume or music.volume,
-				allow_switch = v.allow_switch
+				allow_switch = NotNil(v.allow_switch, true)
 			}
 		end
 	end
 
-	local preview_event = self._config.preview_event or (self.is_stealth and "suspense_4" or "assault")
-	local event = music.events[preview_event]
-
-	if event then
-		music.source = event.source
-		music.start_source = event.source
-	end
+	music.preview_event = self._config.preview_event or (self.is_stealth and "suspense_4" or "assault")
 
 	BeardLib.MusicMods[self._config.id] = music
 end

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -83,7 +83,6 @@ function HeistMusic:RegisterHook()
 			end
 			-- Track handling as part of event tag
 			if #tracks == 0 then
-				self:log("Old loading of %s %s", tostring(self._config.id), tostring(v.name))
 				table.insert(tracks, {
 					start_source = v.start_source and self:MakeBuffer(Path:Combine(dir, v.start_source)),
 					source = v.source and self:MakeBuffer(Path:Combine(dir, v.source)),

--- a/Modules/Addons/MenuMusicModule.lua
+++ b/Modules/Addons/MenuMusicModule.lua
@@ -1,20 +1,29 @@
 MenuMusicModule = MenuMusicModule or BeardLib:ModuleClass("MenuMusic", ItemModuleBase)
 
 function MenuMusicModule:LoadBuffers()
-	for _, source in pairs(BeardLib.MusicMods[self._config.id]) do
-		if type(source) == "table" and source.module then
-			source.buffer = XAudio.Buffer:new(source.path)
+	for _, track in pairs(BeardLib.MusicMods[self._config.id].tracks) do
+		if track.source and track.source.module then
+			track.source.buffer = XAudio.Buffer:new(track.source.path)
+		end
+		if track.start_source and track.start_source.module then
+			track.start_source.buffer = XAudio.Buffer:new(track.start_source.path)
 		end
 	end
 end
 
 function MenuMusicModule:UnloadBuffers()
-	for _, source in pairs(BeardLib.MusicMods[self._config.id]) do
-		if type(source) == "table" and source.module then
-			if source.buffer then
-				source.buffer:close(true)
+	for _, track in pairs(BeardLib.MusicMods[self._config.id].tracks) do
+		if track.source and track.source.module then
+			if track.source.buffer then
+				track.source.buffer:close(true)
 			end
-			source.buffer = nil
+			track.source.buffer = nil
+		end
+		if track.start_source and track.start_source.module then
+			if track.start_source.buffer then
+				track.start_source.buffer:close(true)
+			end
+			track.start_source.buffer = nil
 		end
 	end
 end
@@ -54,7 +63,11 @@ function MenuMusicModule:RegisterHook()
 
 	BeardLib.Utils:SetupXAudio()
 	local music = {menu = true, volume = self._config.volume, xaudio = true}
-	music.source = self:MakeBuffer(self._config.source)
-	music.start_source = self:MakeBuffer(self._config.start_source)
+	music.tracks = {
+		{
+			source = self:MakeBuffer(self._config.source),
+			start_source = self:MakeBuffer(self._config.start_source)
+		}
+	}
 	BeardLib.MusicMods[self._config.id] = music
 end

--- a/Modules/Addons/MusicModule.lua
+++ b/Modules/Addons/MusicModule.lua
@@ -22,10 +22,10 @@ function MusicModule:RegisterHook()
 			for _,t in ipairs(v) do
 				if type(t) == "table" and t._meta == "track" then
 					table.insert(tracks, {
-						start_source = t.start_source and Path:Combine(dir, t.start_source),
-						source = t.source and Path:Combine(dir, t.source),
-						weight = t.weight or 1,
-						volume = t.volume or music.volume
+						start_source = (t.start_source or v.start_source) and Path:Combine(dir, (t.start_source or v.start_source)),
+						source = (t.source or v.source) and Path:Combine(dir, (t.source or v.source)),
+						weight = t.weight or v.weight or 1,
+						volume = t.volume or v.volume or music.volume
 					})
 				end
 			end
@@ -39,7 +39,7 @@ function MusicModule:RegisterHook()
 				})
 				if v.alt_source then -- backwards compat for old alternate track system
 					table.insert(tracks, {
-						start_source = v.alt_start_source and Path:Combine(dir, v.alt_start_source),
+						start_source = (v.alt_start_source or v.start_source) and Path:Combine(dir, (v.alt_start_source or v.start_source)),
 						source = v.alt_source and Path:Combine(dir, v.alt_source),
 						weight = v.alt_chance and v.alt_chance * 100 or 1,
 						volume = v.volume or music.volume

--- a/Modules/Addons/MusicModule.lua
+++ b/Modules/Addons/MusicModule.lua
@@ -77,7 +77,8 @@ function MusicModule:RegisterHook()
 		self._mod._config.AddFiles = AddFilesModule:new(self._mod, add)
 	end
 
-	music.preview_event = self._config.preview_event or "assault"
+	local event = music.events[self._config.preview_event or "assault"]
+	music.tracks = event and event.tracks
 
 	BeardLib.MusicMods[self._config.id] = music
 end


### PR DESCRIPTION
Allows arbitrary number of tracks per event with custom weighting. Events can still be defined as previously, adding multiple tracks to an event is done by placing them as children nodes like so
```
<event name="assault" allow_switch="false">
   <track start_source="Assault_Intro.ogg" source="Assault.ogg" weight="1"/>
   <track start_source="Assault2_Intro.ogg" source="Assault2.ogg" weight="1"/>
</event>
```
Parameters like volume, weight etc are inherited from the event node if they are not specified in the track nodes.