### PR TITLE
Fix for existing mods using packages.

### DIFF
--- a/Classes/Managers/PackageManager.lua
+++ b/Classes/Managers/PackageManager.lua
@@ -146,7 +146,7 @@ function BeardLibPackageManager:LoadConfig(directory, config, mod, settings)
         if use_clbk and mod then
             use_clbk = mod:StringToCallback(use_clbk) or nil
         end
-        if use_clbk and not use_clbk(config) then
+        if use_clbk and type(use_clbk) == "function" and not use_clbk(config) then
             return
         end
     end


### PR DESCRIPTION
Was able to replicate issues wherein packages in existing mods would result in a nil 'mod' value being passed in- causing type related errors and inevitable crashes. Relevant log is posted below:

> 02:08:53 PM FATAL ERROR:  (C:\Users\ZNix\source\repos\SuperBLT\src\InitiateState.cpp:314) mods/BeardLib/Classes/Managers/PackageManager.lua:149: attempt to call local 'use_clbk' (a string value)
> stack traceback:
> 	mods/BeardLib/Classes/Managers/PackageManager.lua:149: in function 'LoadConfig'
> 	mods/BeardLib/Classes/Managers/PackageManager.lua:43: in function 'LoadPackage'
> 	mods/BeardLib/Hooks/CoreSystem.lua:95: in function 'load'
> 	...on-mod/lua/sc/managers/menu/items/CoreItemChallenges.lua:4: in main chunk
> 	[C]: in function 'dofile'
> 	mods/base/base.lua:132: in function 'RunHookFile'
> 	mods/base/base.lua:124: in function 'RunHookTable'
> 	mods/base/base.lua:154: in function 'OrigRequire'
> 	mods/BeardLib/Core.lua:361: in function 'require'
> 	[string "lib/managers/menumanager.lua"]:13: in main chunk
> 	[C]: in function 'require'
> 	...
> 	mods/BeardLib/Core.lua:361: in function 'require'
> 	[string "lib/setups/menusetup.lua"]:1: in main chunk
> 	[C]: in function 'require'
> 	mods/base/base.lua:153: in function 'OrigRequire'
> 	mods/BeardLib/Core.lua:361: in function 'require'
> 	[string "lib/entry.lua"]:13: in main chunk
> 	[C]: in function 'require'
> 	mods/base/base.lua:153: in function 'OrigRequire'
> 	mods/BeardLib/Core.lua:361: in function 'require'
> 	[string "core/lib/coreentry.lua"]:19: in main chunk
> 

This adds an additional sanity check to ensure that use_clbk is a function before it tries to call it. Since it can be either a function or a string.

This may become a moot issue once the next SBLT update is out, but this will address issues that exist now.