### PR TITLE
Fix potential crash with material_variations

### DIFF
--- a/Hooks/PlayerStyleGloveHooks.lua
+++ b/Hooks/PlayerStyleGloveHooks.lua
@@ -712,6 +712,9 @@ elseif F == "blackmarketmanager" then
 
 		local glowobal_bmm = Global.blackmarket_manager.player_styles[player_style].material_variations[material_variation]
 		if material_variation ~= "default" then
+			if not tweak_data.blackmarket.player_styles[player_style].material_variations then
+				return false
+			end
 			local tweak_data = tweak_data.blackmarket.player_styles[player_style].material_variations[material_variation]
 			return (tweak_data and glowobal_bmm) and true or false
 		end


### PR DESCRIPTION
Removing a mod that adds variants to outfits that don't have any in vanilla while still wearing that outfit variant will crash the game on startup since the material_variations table doesnt exist in the tweakdata anymore