### PR TITLE
Fix issue #492

### DIFF
--- a/Hooks/World/CoreWorldDefinition.lua
+++ b/Hooks/World/CoreWorldDefinition.lua
@@ -70,10 +70,8 @@ function WorldDefinition:unload_packages(...)
             self._custom_loaded_packages = {}
         end
     end
-    if not BeardLib.current_level then
-        if self._continent_packages then
-            WorldDefinitionunload_packages(self, ...)
-        end
+    if not BeardLib.current_level and self._continent_packages then
+        WorldDefinitionunload_packages(self, ...)
     end
 end
 


### PR DESCRIPTION
Original function that is called here is using self._continent_packages table, which weren't initialized when you switched levels in the very same map.
It's just a nil check there, worked fine