### PR TITLE
Re-enable grenade spoofing in outfit_string

### DIFF
--- a/Classes/Utils/Sync.lua
+++ b/Classes/Utils/Sync.lua
@@ -245,7 +245,7 @@ function Sync:CleanOutfitString(str, is_henchman)
 			end
 		end
 
-        --list.grenade = self:GetSpoofedGrenade(list.grenade)
+        list.grenade = self:GetSpoofedGrenade(list.grenade)
     end
 
     local player_style = tweak_data.blackmarket.player_styles[list.player_style]


### PR DESCRIPTION
Uncommented the section of the outfit_string syncing responsible for spoofing the equipped grenade to peers.
Although grenade spoofing does not prevent crashing from syncing invalid units, it is still useful (and necessary) to prevent crashing from custom throwable abilities (eg from custom perk decks).