### PR TITLE
Fix #522, custom achievement pack banner

### DIFF
--- a/Classes/UI/AchievementMenu.lua
+++ b/Classes/UI/AchievementMenu.lua
@@ -343,12 +343,7 @@ function BeardLibAchievementMenu:DisplayPackageHeader(package)
 		banner_panel:Panel():bitmap({
 			texture = banner,
 			w = banner_panel:Panel():w(),
-			h = banner_panel:Panel():h()
-		})
-		banner_panel:Panel():bitmap({
-			w = banner_panel:Panel():w(),
 			h = banner_panel:Panel():h(),
-			color = Color.black,
 			layer = 2
 		})
 	end


### PR DESCRIPTION
Fix #522
Note: From my testing, the image must be a .texture with a resolution of EXACTLY 820x90.