### PR TITLE
Fixed ElementRelativeTeleport not teleporting clients.

### DIFF
--- a/Classes/Elements/ElementRelativeTeleport.lua
+++ b/Classes/Elements/ElementRelativeTeleport.lua
@@ -4,6 +4,10 @@ ElementRelativeTeleport = ElementRelativeTeleport or class(CoreMissionScriptElem
 -- AIGroupType Element
 -- Creator: Cpone
 
+function ElementRelativeTeleport:client_on_executed(...)
+	self:on_executed(...)
+end
+
 function ElementRelativeTeleport:on_executed(instigator)
 	if not self._values.enabled then
 		return
@@ -12,6 +16,8 @@ function ElementRelativeTeleport:on_executed(instigator)
 	if self._values.target and #self._values.target > 1 then
 		return
 	end
+
+	ElementRelativeTeleport.super.on_executed(self, instigator, ...)
 
 	if instigator and alive(instigator) then
 		local instigator_position = instigator:position()


### PR DESCRIPTION
ElementRelativeTeleport did not call the correct methods to properly sync teleports to clients.