### PR TITLE
Improve custom music volume multipliers

### DIFF
--- a/Hooks/DialogManager.lua
+++ b/Hooks/DialogManager.lua
@@ -1,11 +1,7 @@
 Hooks:PostHook(DialogManager, "_play_dialog", "BeardLibDialogManagerPlayDialog", function (self)
-	if self._current_dialog.unit == self._bain_unit and managers.music._xa_source then
-		managers.music._xa_source:set_volume(managers.music._xa_volume * 0.5)
-	end
+	managers.music:set_volume_multiplier(0.5)
 end)
 
 Hooks:PostHook(DialogManager, "_stop_dialog", "BeardLibDialogManagerStopDialog", function ()
-	if managers.music._xa_source then
-		managers.music._xa_source:set_volume(managers.music._xa_volume)
-	end
+	managers.music:set_volume_multiplier(1, 1)
 end)

--- a/Hooks/PlayerDamage.lua
+++ b/Hooks/PlayerDamage.lua
@@ -1,0 +1,8 @@
+Hooks:PostHook(PlayerDamage, "_start_tinnitus", "BeardLibPlayerDamageStartTinnitus", function (self, sound_eff_mul)
+	if not self._tinnitus_data then
+		return
+	end
+
+	managers.music:set_volume_multiplier(0)
+	managers.music:set_volume_multiplier(1, self._tinnitus_data.duration * 2)
+end)

--- a/main.xml
+++ b/main.xml
@@ -161,6 +161,7 @@
 			<hook source_file="lib/managers/musicmanager" file="MusicManager.lua"/>
 
 			<hook source_file="lib/managers/dialogmanager" file="DialogManager.lua"/>
+			<hook source_file="lib/units/beings/player/playerdamage" file="PlayerDamage.lua"/>
 
 			<hooks directory="Network">
 				<hook source_file="lib/units/beings/player/huskplayermovement" file="NetworkHooks.lua"/>


### PR DESCRIPTION
Made an actual function to control volume multiplier that also allows setting a fade duration for less abrupt volume changes.
The changes now also apply to old music mods using movie files, and an additional potential crash has been fixed.
Also added a volume fade for when getting flashbanged.