### PR TITLE
Fixed custom music never being unloaded.

### DIFF
--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -211,8 +211,6 @@ function MusicManager:play(src, use_xaudio, custom_volume)
 	
 	if use_xaudio then
 		if XAudio then
-
-
 			if type(src) == "table" and src.module then
 				if self._last_module and self._last_module ~= src.module then
 					self._last_module:UnloadBuffers()

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -209,14 +209,16 @@ function MusicManager:play(src, use_xaudio, custom_volume)
 	self:stop_custom()
 	Global.music_manager.source:post_event("stop_all_music")
 	
-	if type(src) == "table" and src.module and self._last_module and self._last_module ~= src.module then
-		self._last_module:UnloadBuffers()
-		self._last_module = nil
-	end
-	
 	if use_xaudio then
 		if XAudio then
+
+
 			if type(src) == "table" and src.module then
+				if self._last_module and self._last_module ~= src.module then
+					self._last_module:UnloadBuffers()
+					self._last_module = nil
+				end
+
 				if not src.buffer then
 					src.module:LoadBuffers()
 				end

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -208,10 +208,12 @@ end
 function MusicManager:play(src, use_xaudio, custom_volume)
 	self:stop_custom()
 	Global.music_manager.source:post_event("stop_all_music")
-	--Uncomment if unloading is ever needed
-	--[[if type(src) == "table" and src.module and self._last_module and self._last_module ~= src.module then
-		self._last_buffer.module:UnloadBuffers()
-	end]]
+	
+	if type(src) == "table" and src.module and self._last_module and self._last_module ~= src.module then
+		self._last_module:UnloadBuffers()
+		self._last_module = nil
+	end
+	
 	if use_xaudio then
 		if XAudio then
 			if type(src) == "table" and src.module then
@@ -222,10 +224,8 @@ function MusicManager:play(src, use_xaudio, custom_volume)
 					BeardLib:log("Something went wrong while trying to play the source")
 					return
 				end
-				src = src.buffer
 				self._last_module = src.module
-			else
-				self._last_module = nil
+				src = src.buffer
 			end
 			self._xa_volume = custom_volume or 1
 			self._xa_source = XAudio.Source:new(src)


### PR DESCRIPTION
Resolved issue #514. The code to unload buffers when a new song is selected was commented out, so I've uncommented it. The code also suffered from some bitrot over time due to disuse, so I've taken the liberty to update it.

This change does slightly worsen the loading stutter when songs are switched, so it may be preferable long term to potentially change the behavior of the loading/unloading buffers to spread work across multiple frames. However, for now, it shouldn't be a critical issue since the relevant function generally isn't called during gameplay.