### PR TITLE
Skip LoadFileFromDB if asset is already loaded by the game

### DIFF
--- a/Classes/Managers/FileManager.lua
+++ b/Classes/Managers/FileManager.lua
@@ -141,6 +141,11 @@ function BeardLibFileManager:AddFile(ext, path, file)
 end
 
 function BeardLibFileManager:LoadFileFromDB(ext, path)
+	if PackageManager:has(Idstring(ext), Idstring(path)) then
+		BeardLib:DevLog("Skipping DB load of already loaded file '%s.%s'", path, ext)
+		return
+	end
+
 	if self:Has(ext, path) then
 		return
 	end


### PR DESCRIPTION
This prevents crashes in cases where it would load a file that is already loaded and has been asset tweaked with SuperBLT before