### PR TITLE
Add Optional Versions to Mods

### DIFF
--- a/Classes/Providers/Github.lua
+++ b/Classes/Providers/Github.lua
@@ -16,7 +16,7 @@ function github:check_func()
         return
     end
 
-    local check_url = self._config.release and github.check_url_release or github.check_url
+    local check_url = self.config.release and github.check_url_release or github.check_url
     local upd = Global.beardlib_checked_updates[self.id]
 
     if upd then
@@ -27,7 +27,7 @@ function github:check_func()
         return
     end
 
-    local check_url = ModCore:GetRealFilePath(check_url, self._config)
+    local check_url = ModCore:GetRealFilePath(check_url, self.config)
     dohttpreq(check_url, function(data, id)
         if data then
             data = json.decode(data)
@@ -46,7 +46,7 @@ function github:check_func()
             local length_acceptable = (string.len(self._new_version) > 0 and string.len(self._new_version) <= 64)
 
             if length_acceptable and tostring(self._new_version) ~= tostring(self.version) then
-                if self._config.release and data.assets[1].browser_download_url then
+                if self.config.release and data.assets[1].browser_download_url then
                     self._github_download_url = data.assets[1].browser_download_url
                 end
                 Global.beardlib_checked_updates[self.id] = data
@@ -61,11 +61,11 @@ end
 function github:download_file_func(data)
     local download_url
     --Avoid adding the callback if release, hash doesn't need to be updated.
-    if self._config.release then
+    if self.config.release then
         download_url = self._github_download_url
     else
-        download_url = ModCore:GetRealFilePath(github.download_url, data or self._config)
-        table.merge(self._config, {
+        download_url = ModCore:GetRealFilePath(github.download_url, data or self.config)
+        table.merge(self.config, {
             done_callback = SimpleClbk(github.done_callback, self)
         })
     end

--- a/Classes/Providers/Modworkshop.lua
+++ b/Classes/Providers/Modworkshop.lua
@@ -24,7 +24,7 @@ function mws:check_func()
             data = string.sub(data, 0, #data - 1)
             local not_bool = (data ~= "false" and data ~= "true")
             local length_acceptable = (string.len(data) > 0 and string.len(data) <= 64)
-            local version_check = not self._config.version_is_number or ((tonumber(self.version) and tonumber(data)) and tonumber(self.version) < tonumber(data))
+            local version_check = not self.config.version_is_number or ((tonumber(self.version) and tonumber(data)) and tonumber(self.version) < tonumber(data))
 
             if not_bool and length_acceptable and version_check then
                 self._new_version = data

--- a/Classes/UI/ModsMenu.lua
+++ b/Classes/UI/ModsMenu.lua
@@ -352,6 +352,26 @@ function BeardLibModsMenu:OpenModSettings(mod, blt_mod)
                 value = mod_settings.IgnoreUpdates,
                 on_callback = ClassClbk(self, "SetModSetting", mod)
             })
+            if mod.AssetUpdates and mod.AssetUpdates._config.optional_versions then
+                holder:ComboBox({
+                    name = "OptionalVersion",
+                    value = mod:GetSetting("OptionalVersion"),
+                    text = "beardlib_mod_optional_version",
+                    help = "beardlib_mod_optional_version_help",
+                    items_localized = false,
+                    free_typing = true, -- this isn't really needed, but string keys.
+                    on_callback = ClassClbk(self, "SetModSetting", mod),
+                    --Using string keys due to indexes sometimes not being correct, messy
+                    items = table.remap(mod.AssetUpdates._config.optional_versions,
+                    function (k, _)
+                        if type(k) == "string" and k ~= "_meta" then
+                            return k, k
+                        end
+
+                        return "stable", "stable" --can't be nil and need to add stable as an option anyways.
+                    end)
+                })
+            end
         end
     })
 end

--- a/Localization/english.yaml
+++ b/Localization/english.yaml
@@ -100,14 +100,18 @@ beardlib_show_errors_dialog_help: |
   So you can either update the mod or remove it.
   Note: You should keep this on when using developer mode.
 beardlib_mod_develop_mode: "Develop Mode"
-beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto updates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+  Selecting a optional version will switch your auto updates to that version.
+  These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+  By enabling this, you will get updates from GitHub rather than modworkshop.
+  The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/french.yaml
+++ b/Localization/french.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Note : Vous devriez faire ça avec le mode développeur
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/german.yaml
+++ b/Localization/german.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Hinweis: Du solltest dies aktiviert lassen, wenn du den Entwickler Modus verwendest.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/italian.yaml
+++ b/Localization/italian.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Nota: Dovresti tenere questa impostazione attivata in modalità sviluppatore.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/portuguese.yaml
+++ b/Localization/portuguese.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Nota: Você deveria manter isso só quando estiver em modo de desenvolvedor.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/russian.yaml
+++ b/Localization/russian.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Примечание: не выключайте данную опцию, если вы используете режим разрабочика.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/schinese.yaml
+++ b/Localization/schinese.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     注意: 您需要启用开发者模式才能使用该功能。
 beardlib_mod_develop_mode: "开发模式"
 beardlib_mod_develop_mode_help: "若要为此模组激活开发模式，则自动更新将被禁用，并且诸如自动生成的附加文件将在每次重载时刷新。"
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "在左侧面板选择一个成就包以显示其相关的成就。"
 beardlib_log_init: "模组日志初始化"
 beardlib_log_init_help: "当模组初始化时初始化模组的日志。"
 beardlib_custom_maps_only: "仅自定义劫案"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "自定义手套"
 bm_menu_btn_customize_gloves: "自定义手套"

--- a/Localization/spanish.yaml
+++ b/Localization/spanish.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
     Nota: Deberias mantenener esta opcion habilitada mientras usas modo Desarollador.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+    Selecting a optional version will switch your auto updates to that version.
+    These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+    By enabling this, you will get updates from GitHub rather than modworkshop.
+    The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"

--- a/Localization/swedish.yaml
+++ b/Localization/swedish.yaml
@@ -101,13 +101,17 @@ beardlib_show_errors_dialog_help: |
    Note: You should keep this on when using developer mode.
 beardlib_mod_develop_mode: "Develop Mode"
 beardlib_mod_develop_mode_help: "By activating develop mode for the mod, auto uppdates will be disabled and things such as auto generated addfiles will refresh each reload."
+beardlib_mod_optional_version: "Optional Version"
+beardlib_mod_optional_version_help: | 
+   Selecting a optional version will switch your auto updates to that version.
+   These are likely in an expermiental state and may contain new features and bugs.
 beardlib_achieves_no_pkg: "Select a package on the left panel to show the achievements related to it."
 beardlib_log_init: "Log initialization of mods"
 beardlib_log_init_help: "Logs initialization of mods when they are initialized."
 beardlib_custom_maps_only: "Custom Maps Only"
 beardlib_github_updates: "GitHub / Beta Updates"
 beardlib_github_updates_help: |
- By enabling this, you will get updates from GitHub rather than modworkshop.
- The GitHub version is in an experimental state and may have new features and bugs.
+   By enabling this, you will get updates from GitHub rather than modworkshop.
+   The GitHub version is in an experimental state and may have new features and bugs.
 bm_menu_glove_variations: "Customize Gloves"
 bm_menu_btn_customize_gloves: "Customize Gloves"


### PR DESCRIPTION
Adds the ability to have optional versions on mods using AssetUpdates modules.

<img width="709" alt="payday2_win32_release_0j3INkIqf7" src="https://user-images.githubusercontent.com/13400548/190287534-dc689c44-e813-4a7a-acea-d9e096d415d3.png">



```xml
<!-- Root is the stable branch -->
<AssetUpdates provider="github" custom_name="GitHub Update" branch="master" id="Makowo/BeardLib-Editor" dont_delete="true">
<!-- Versions are AssetUpdate modules with the version/branch name replacing the meta. -->
    <optional_versions>
        <alpha provider="github" custom_name="GitHub Update" branch="testinggithubupdates" id="Makowo/BeardLib-Editor" dont_delete="true" />
        <beta provider="github" custom_name="GitHub Update" branch="testing-beta" id="Makowo/BeardLib-Editor" dont_delete="true" />
        <release_candidate provider="github" custom_name="GitHub Update" release="true" version="2" id="Makowo/BeardLib-Editor" dont_delete="true" />
        <latest provider="github" custom_name="GitHub Update" branch="master" id="Makowo/BeardLib-Editor" dont_delete="true" />
        <latest-dev id="14924" version="4.8" provider="modworkshop" important="true" version_is_number="true"/>
    </optional_versions>
</AssetUpdates>
```
