### PR TITLE
Add expression evaluation to number textboxes

### DIFF
--- a/Classes/UI/MenuUI/Item.lua
+++ b/Classes/UI/MenuUI/Item.lua
@@ -281,7 +281,8 @@ function Item:WorkParams(params)
 	self:WorkParam("slider_slice", 0.7)
 	self:WorkParam("textbox_max_h", 75)
 	self:WorkParam("textbox_scroll_color")
-    self:WorkParam("scroll_speed", 48)
+	self:WorkParam("scroll_speed", 48)
+	self:WorkParam("allow_expressions", true)
 
 	if not managers.menu:is_pc_controller() then
         self.scroll_speed = self.scroll_speed * 0.5

--- a/Classes/UI/MenuUI/TextBox.lua
+++ b/Classes/UI/MenuUI/TextBox.lua
@@ -6,20 +6,21 @@ function TextBox:Init()
 	TextBox.super.Init(self)
 	self:WorkParam("floats", 3)
 	if self.filter == "number" then
-    	self.value = tonumber(self.value) or 0
-    end
+		self.value = tonumber(self.value) or 0
+		self.allow_expressions = NotNil(self.allow_expressions, true)
+	end
 	self._textbox = BeardLib.Items.TextBoxBase:new(self, {
-        panel = self.panel,
+		panel = self.panel,
 		fit_text = NotNil(self.fit_text, self.filter == "number"),
 		lines = self.filter == "number" and 1 or nil,
 		focus_mode = self.focus_mode,
 		auto_focus = self.auto_focus,
-        line_color = self.line_color or self.highlight_color,
-        w = self.panel:w() * (not self.text and 1 or self.control_slice),
-        value = self.value,
+		line_color = self.line_color or self.highlight_color,
+		w = self.panel:w() * (not self.text and 1 or self.control_slice),
+		value = self.value,
 	})
 	self.auto_focus = nil
-    self.value = self.value or ""
+	self.value = self.value or ""
 	self._textbox:PostInit()
 end
 


### PR DESCRIPTION
Allows the use of math operations in text boxes that are set to numbers only. Expressions will be evaluated on text box validation.
Expression evaluation is on by default for number textboxes and can be disabled by setting the `allow_expressions` paramter of the textbox to `false`.