### PR TITLE
Load a lighter version of BeardLib during the loading environment.

### DIFF
--- a/Classes/Frameworks/AddFramework.lua
+++ b/Classes/Frameworks/AddFramework.lua
@@ -31,8 +31,7 @@ function AddFramework:FindMods()
                 BeardLib:Err("Could not read %s", main_file)
             end
 			if FileIO:Exists(add_file) then
-                local data = FileIO:ReadFrom(add_file)
-                local config = ScriptSerializer:from_custom_xml(data)
+                local config = FileIO:ReadConfig(add_file)
                 local directory = config.full_directory or Path:Combine(p, config.directory)
                 BeardLib.Managers.Package:LoadConfig(directory, config)
                 self.add_configs[p] = config

--- a/Classes/Frameworks/FrameworkBase.lua
+++ b/Classes/Frameworks/FrameworkBase.lua
@@ -30,7 +30,7 @@ function FrameworkBase:init()
 	self._log_init = BeardLib.Options:GetValue("LogInit")
 
 	-- Deprecated, try not to use.
-	if self.type_name == AddFramework.type_name then
+	if AddFramework and self.type_name == AddFramework.type_name then
 		BeardLib.Frameworks.base = self
 		BeardLib.managers.BaseFramework = self
 	end

--- a/Classes/ModCore.lua
+++ b/Classes/ModCore.lua
@@ -34,8 +34,6 @@ function ModCore:init(config_path, load_modules)
     end
 end
 
-local TEXTURE = Idstring("texture")
-
 function ModCore:PostInit(ignored_modules)
     if self._post_init_done then
         return
@@ -76,6 +74,7 @@ function ModCore:PostInit(ignored_modules)
 	self._post_init_done = true
 end
 
+local TEXTURE = Idstring("texture")
 function ModCore:LoadConfigFile(path)
     local config = FileIO:ReadConfig(path)
 
@@ -101,20 +100,21 @@ function ModCore:LoadConfigFile(path)
         end
     end
 
-
-    local icon = Path:Combine(self.ModPath, "icon")
-    local icon_png = icon..".png"
-    local icon_texture = icon..".texture"
-    local found_icon
-    if FileIO:Exists(icon_png) then
-        found_icon = icon_png
-    elseif FileIO:Exists(icon_texture) then
-        found_icon = icon_texture
-    end
-    if found_icon then
-        local ingame_path = Path:Combine("guis/textures/mods/icons", "mod_"..self.ModPath:key())
-        BeardLib.Managers.File:AddFile(TEXTURE, Idstring(ingame_path), found_icon)
-        config.image = ingame_path
+    if not CoreLoadingSetup then
+        local icon = Path:Combine(self.ModPath, "icon")
+        local icon_png = icon..".png"
+        local icon_texture = icon..".texture"
+        local found_icon
+        if FileIO:Exists(icon_png) then
+            found_icon = icon_png
+        elseif FileIO:Exists(icon_texture) then
+            found_icon = icon_texture
+        end
+        if found_icon then
+            local ingame_path = Path:Combine("guis/textures/mods/icons", "mod_"..self.ModPath:key())
+            BeardLib.Managers.File:AddFile(TEXTURE, Idstring(ingame_path), found_icon)
+            config.image = ingame_path
+        end
     end
 
     self._clean_config = deep_clone(config)
@@ -197,7 +197,7 @@ function ModCore:AddModule(module_tbl)
                 else
                     self:Err("An error occurred on initilization of module: %s. Error:\n%s", meta, tostring(node_obj))
                 end
-            elseif not self._config.ignore_errors then
+            elseif not (self._config.ignore_errors or CoreLoadingSetup) then
                 self:Err("Unable to find module with key %s", meta)
             end
         end

--- a/CoreLoading.lua
+++ b/CoreLoading.lua
@@ -1,7 +1,6 @@
 BeardLibModPath = ModPath
 
 _G.Global = {}
-
 _G.Application = {}
 _G.Application.ews_enabled = function() return false end
 setmetatable(_G.Application, _G.Application)
@@ -26,3 +25,8 @@ function Idstring(string)
 end
 
 dofile(BeardLibModPath .. "Core.lua")
+
+-- Cleanup most of important globals that might accidentally trigger something else.
+_G.core = nil
+_G.Global = nil
+_G.Application = nil

--- a/CoreLoading.lua
+++ b/CoreLoading.lua
@@ -1,0 +1,28 @@
+BeardLibModPath = ModPath
+
+_G.Global = {}
+
+_G.Application = {}
+_G.Application.ews_enabled = function() return false end
+setmetatable(_G.Application, _G.Application)
+
+require("core/lib/system/CoreModule")
+core:register_module("core/lib/utils/CoreSerialize")
+core:register_module("core/lib/utils/CoreCode")
+core:register_module("core/lib/utils/CoreClass")
+core:register_module("core/lib/utils/CoreDebug")
+core:register_module("core/lib/utils/CoreTable")
+core:register_module("core/lib/utils/CoreString")
+core:register_module("core/lib/utils/CoreApp")
+core:_copy_module_to_global("CoreCode")
+core:_copy_module_to_global("CoreClass")
+core:_copy_module_to_global("CoreDebug")
+core:_copy_module_to_global("CoreTable")
+core:_copy_module_to_global("CoreString")
+core:_copy_module_to_global("CoreApp")
+
+function Idstring(string)
+	return str
+end
+
+dofile(BeardLibModPath .. "Core.lua")

--- a/Modules/Addons/LevelModule.lua
+++ b/Modules/Addons/LevelModule.lua
@@ -1,3 +1,24 @@
+if CoreLoadingSetup then
+    LevelModule = LevelModule or BeardLib:ModuleClass("level", ItemModuleBase)
+    LevelModule.levels_folder = "levels/mods/"
+
+    function LevelModule:init(...)
+        if not LevelModule.super.init(self, ...) then  return false end
+
+        if arg and arg.load_level_data and arg.load_level_data.level_data and arg.load_level_data.level_data.level_id == self._config.id then
+            self:Load()
+        end
+    end
+
+    function LevelModule:Load()
+        if self._config.hooks then
+            HooksModule:new(self._mod, self._config.hooks)
+        end
+    end
+
+    return
+end
+
 LevelModule = LevelModule or BeardLib:ModuleClass("level", ItemModuleBase)
 LevelModule.levels_folder = "levels/mods/"
 

--- a/main.xml
+++ b/main.xml
@@ -269,6 +269,29 @@
 			</classes>
 		</classes>
 	</classes>
+	<loading_classes>
+		<classes directory="Classes">
+			<class file="Constants.lua"/>
+			<class file="ModCore.lua"/>
+			<class file="ModuleBase.lua"/>
+			<class file="Deprecated.lua"/>
+
+			<classes directory="Utils">
+				<class file="Table.lua"/>
+				<class file="Hooks.lua"/>
+				<class file="JSON.lua"/>
+			</classes>
+
+			<classes directory="Frameworks">
+				<class file="FrameworkBase.lua"/>
+				<class file="MapFramework.lua"/>
+			</classes>
+		</classes>
+	</loading_classes>
+	<load_enabled_modules>
+		<value_node value="HooksModule"/>
+		<value_node value="OptionModule"/>
+	</load_enabled_modules>
 	<mission_elements>
 		<value_node value="MoveUnit"/>
 		<value_node value="RotateUnit"/>

--- a/main.xml
+++ b/main.xml
@@ -290,6 +290,7 @@
 	</loading_classes>
 	<load_enabled_modules>
 		<value_node value="HooksModule"/>
+		<value_node value="LevelModule"/>
 		<value_node value="OptionModule"/>
 	</load_enabled_modules>
 	<mission_elements>

--- a/mod.txt
+++ b/mod.txt
@@ -10,7 +10,7 @@
 	"color" : "0 0.44 1",
 	"image" : "Assets/guis/textures/beardlib_logo.texture",
 	"hooks" : [
-		{"hook_id" : "core/lib/system/coresystem", "script_path" : "Core.lua"}
+		{"hook_id" : "core/lib/system/coresystem", "script_path" : "Core.lua"},
 		{"hook_id" : "core/lib/setups/coreloadingsetup", "script_path" : "CoreLoading.lua"}
 	]
 }

--- a/mod.txt
+++ b/mod.txt
@@ -11,5 +11,6 @@
 	"image" : "Assets/guis/textures/beardlib_logo.texture",
 	"hooks" : [
 		{"hook_id" : "core/lib/system/coresystem", "script_path" : "Core.lua"}
+		{"hook_id" : "core/lib/setups/coreloadingsetup", "script_path" : "CoreLoading.lua"}
 	]
 }


### PR DESCRIPTION
Load a lighter version of BeardLib during the loading environment so that hooks can interact with loading-related Lua files.

This is primarily useful for custom loading screens, both as an "override" or within a map.

Right now only the Options module, Hooks module, and the hook portion of the level module are set up to run in this state. But this can definitely be expanded to further modules in the future.

I've ironed out most of the kinks with utilising BLTs XML parser as ScriptSerializer is unavailable during the loading environment, but there might be other quirky XML files that trip it up.