### PR TITLE
Allow music switch per track

### DIFF
--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -187,10 +187,10 @@ function MusicManager:attempt_play(track, event, stop)
 	end
 
 	local volume = next_track.volume or next_event.volume or next_music.volume
-	self._switch_at_end = (next_track.start_source or next_event.allow_switch and #next_event.tracks > 1) and {
+	self._switch_at_end = (next_track.start_source or next_track.allow_switch and #next_event.tracks > 1) and {
 		tracks = next_event.tracks,
 		track_index = next_track.start_source and track_index or self:pick_track_index(next_event.tracks),
-		allow_switch = next_event.allow_switch,
+		allow_switch = next_track.allow_switch,
 		xaudio = next_music.xaudio,
 		volume = volume
 	}

--- a/Hooks/MusicManager.lua
+++ b/Hooks/MusicManager.lua
@@ -186,16 +186,13 @@ function MusicManager:attempt_play(track, event, stop)
 		end
 	end
 
-	local volume = next_track.volume or next_event.volume or next_music.volume
 	self._switch_at_end = (next_track.start_source or next_track.allow_switch and #next_event.tracks > 1) and {
 		tracks = next_event.tracks,
 		track_index = next_track.start_source and track_index or self:pick_track_index(next_event.tracks),
-		allow_switch = next_track.allow_switch,
-		xaudio = next_music.xaudio,
-		volume = volume
+		xaudio = next_music.xaudio
 	}
 
-	self:play(source, next_music.xaudio, volume)
+	self:play(source, next_music.xaudio, next_track.volume)
 
 	return true
 end
@@ -296,15 +293,13 @@ function MusicManager:custom_update(t, dt, paused)
 	elseif self._switch_at_end then
 		if (self._xa_source and self._xa_source:is_closed()) or (gui_ply and gui_ply:current_frame() >= gui_ply:frames()) then
 			local switch = self._switch_at_end
-			local source = switch.tracks[switch.track_index].source
-			local volume = switch.tracks[switch.track_index].volume or switch.volume
-			if switch.allow_switch and #switch.tracks > 1 then
+			local track = switch.tracks[switch.track_index]
+			if track.allow_switch and #switch.tracks > 1 then
 				switch.track_index = self:pick_track_index(switch.tracks)
-				switch.volume = volume
 			else
 				self._switch_at_end = nil
 			end
-			self:play(source, switch.xaudio, volume)
+			self:play(track.source, switch.xaudio, track.volume)
 		end
 	end
 end

--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -93,7 +93,13 @@ function HeistMusic:RegisterHook()
 	else
 		dir = self._mod.ModPath
 	end
-	local music = {[self.is_stealth and "stealth" or "heist"] = true, volume = self._config.volume, xaudio = true, events = {}}
+	local music = {
+		[self.is_stealth and "stealth" or "heist"] = true,
+		volume = self._config.volume,
+		allow_switch = NotNil(self._config.allow_switch, true),
+		xaudio = true,
+		events = {}
+	}
 	BeardLib.Utils:SetupXAudio()
 
 	for k,v in ipairs(self._config) do
@@ -106,7 +112,8 @@ function HeistMusic:RegisterHook()
 						start_source = (t.start_source or v.start_source) and self:MakeBuffer(Path:Combine(dir, (t.start_source or v.start_source))),
 						source = (t.source or v.source) and self:MakeBuffer(Path:Combine(dir, (t.source or v.source))),
 						weight = t.weight or v.weight or 1,
-						volume = t.volume or v.volume or music.volume
+						volume = t.volume or v.volume or music.volume,
+						allow_switch = NotNil(t.allow_switch, v.allow_switch, music.allow_switch)
 					})
 				end
 			end
@@ -116,14 +123,16 @@ function HeistMusic:RegisterHook()
 					start_source = v.start_source and self:MakeBuffer(Path:Combine(dir, v.start_source)),
 					source = v.source and self:MakeBuffer(Path:Combine(dir, v.source)),
 					weight = v.alt_chance and (1 - v.alt_chance) * 100 or 1,
-					volume = v.volume or music.volume
+					volume = v.volume or music.volume,
+					allow_switch = NotNil(v.allow_switch, music.allow_switch)
 				})
 				if v.alt_source then -- backwards compat for old alternate track system
 					table.insert(tracks, {
 						start_source = (v.alt_start_source or v.start_source) and self:MakeBuffer(Path:Combine(dir, (v.alt_start_source or v.start_source))),
 						source = v.alt_source and self:MakeBuffer(Path:Combine(dir, v.alt_source)),
 						weight = v.alt_chance and v.alt_chance * 100 or 1,
-						volume = v.volume or music.volume
+						volume = v.volume or music.volume,
+						allow_switch = NotNil(v.allow_switch, music.allow_switch)
 					})
 				end
 			end
@@ -136,7 +145,7 @@ function HeistMusic:RegisterHook()
 			music.events[v.name] = {
 				tracks = tracks,
 				volume = v.volume or music.volume,
-				allow_switch = NotNil(v.allow_switch, true)
+				allow_switch = NotNil(v.allow_switch, music.allow_switch)
 			}
 		end
 	end

--- a/Modules/Addons/MusicModule.lua
+++ b/Modules/Addons/MusicModule.lua
@@ -4,7 +4,13 @@ function MusicModule:RegisterHook()
 	self._config.id = self._config.id or "Err"
 
 	local dir = self._config.directory
-	local music = {menu = self._config.menu, heist = self._config.heist, volume = self._config.volume, events = {}}
+	local music = {
+		menu = self._config.menu,
+		heist = self._config.heist,
+		volume = self._config.volume,
+		allow_switch = NotNil(self._config.allow_switch, true),
+		events = {}
+	}
 
 	for k,v in ipairs(self._config) do
 		if type(v) == "table" and v._meta == "event" then
@@ -18,7 +24,8 @@ function MusicModule:RegisterHook()
 						start_source = start_sauce and (dir and Path:Combine(dir, start_sauce) or start_sauce),
 						source = sauce and (dir and Path:Combine(dir, sauce) or sauce),
 						weight = t.weight or v.weight or 1,
-						volume = t.volume or v.volume or music.volume
+						volume = t.volume or v.volume or music.volume,
+						allow_switch = NotNil(t.allow_switch, v.allow_switch, music.allow_switch)
 					})
 				end
 			end
@@ -28,7 +35,8 @@ function MusicModule:RegisterHook()
 					start_source = v.start_source and (dir and Path:Combine(dir, v.start_source) or v.start_source),
 					source = v.source and (dir and Path:Combine(dir, v.source) or v.source),
 					weight = v.alt_chance and v.alt_chance * 100 or 1,
-					volume = v.volume or music.volume
+					volume = v.volume or music.volume,
+					allow_switch = NotNil(v.allow_switch, music.allow_switch)
 				})
 				if v.alt_source then -- backwards compat for old alternate track system
 					local sauce = v.alt_start_source or v.start_source
@@ -36,7 +44,8 @@ function MusicModule:RegisterHook()
 						start_source = (v.alt_start_source or v.start_source) and (dir and Path:Combine(dir, sauce) or sauce),
 						source = dir and Path:Combine(dir, v.alt_source) or v.alt_source,
 						weight = v.alt_chance and v.alt_chance * 100 or 1,
-						volume = v.volume or music.volume
+						volume = v.volume or music.volume,
+						allow_switch = NotNil(v.allow_switch, music.allow_switch)
 					})
 				end
 			end
@@ -49,7 +58,7 @@ function MusicModule:RegisterHook()
 			music.events[v.name] = {
 				tracks = tracks,
 				volume = v.volume or music.volume,
-				allow_switch = NotNil(v.allow_switch, true)
+				allow_switch = NotNil(v.allow_switch, music.allow_switch)
 			}
 		end
 	end


### PR DESCRIPTION
The `allow_switch` flag can now be set per track (or globally) instead of just on the event node.