### PR TITLE
fix: GitHub provider writing to old version file

### DIFF
--- a/Classes/Providers/Github.lua
+++ b/Classes/Providers/Github.lua
@@ -74,8 +74,8 @@ function github:download_file_func(data)
 end
 
 --Callback for updating with the downloaded hash, to not have it show as needing update everytime.
-function github:done_callback()
+function github:done_callback(folder_dir)
     if self.version_file then
-        FileIO:WriteTo(self.version_file, self._new_version)
+        FileIO:WriteTo(folder_dir .. "/" .. "version.txt", self._new_version)
     end
 end

--- a/Modules/Utils/ModAssetsModule.lua
+++ b/Modules/Utils/ModAssetsModule.lua
@@ -297,7 +297,8 @@ function ModAssetsModule:StoreDownloadedAssets(data, id)
         FileIO:Delete(temp_extract_path)
 
         if config.done_callback then
-            config.done_callback()
+            --Provide the directory of extracted folder
+            config.done_callback(dir .. "/" .. extracted_folders[1])
         end
         self.version = self._new_version
         if config.finish then


### PR DESCRIPTION
Fixes an issue where the GitHub provider would write a new version.txt in the previous install directory if the folder name had changed.

Fixed by providing the new install directory to done_callback in ModAssetsModule.

Closes #642