### PR TITLE
File check when loading/parsing a mod in the loading scene.

### DIFF
--- a/Classes/Frameworks/AddFramework.lua
+++ b/Classes/Frameworks/AddFramework.lua
@@ -25,16 +25,28 @@ function AddFramework:FindMods()
             local p = path:CombineDir(self._directory, dir)
             local main_file = path:Combine(p, self.main_file_name)
             local add_file = path:Combine(p, self.add_file)
-            if FileIO:Exists(main_file) then
-                self:LoadMod(dir, p, main_file)
-            elseif not self._ignore_detection_errors then
-                BeardLib:Err("Could not read %s", main_file)
+
+            local do_load = true
+            if CoreLoadingSetup then
+                local loading_scene_file = path:Combine(directory, self.loading_scene_file_name)
+                if not FileIO:Exists(loading_scene_file) then
+                    do_load = false
+                end
             end
-			if FileIO:Exists(add_file) then
-                local config = FileIO:ReadConfig(add_file)
-                local directory = config.full_directory or Path:Combine(p, config.directory)
-                BeardLib.Managers.Package:LoadConfig(directory, config)
-                self.add_configs[p] = config
+
+            if do_load then
+                if FileIO:Exists(main_file) then
+                    self:LoadMod(dir, p, main_file)
+                elseif not self._ignore_detection_errors then
+                    BeardLib:Err("Could not read %s", main_file)
+                end
+
+    			if FileIO:Exists(add_file) then
+                    local config = FileIO:ReadConfig(add_file)
+                    local directory = config.full_directory or Path:Combine(p, config.directory)
+                    BeardLib.Managers.Package:LoadConfig(directory, config)
+                    self.add_configs[p] = config
+                end
             end
         end
     end

--- a/Classes/Frameworks/FrameworkBase.lua
+++ b/Classes/Frameworks/FrameworkBase.lua
@@ -15,6 +15,7 @@ FrameworkBase._ignore_folders = {["base"] = true, ["BeardLib"] = true, ["PAYDAY-
 FrameworkBase._ignore_detection_errors = true
 
 FrameworkBase.main_file_name = "main.xml"
+FrameworkBase.loading_scene_file_name = "enable_in_loading_scene"
 FrameworkBase.auto_init_modules = true
 FrameworkBase.type_name = "Base"
 FrameworkBase.menu_color = Color(0.6, 0, 1)
@@ -88,7 +89,16 @@ function FrameworkBase:FindMods()
                 local directory = path:CombineDir(self._directory, folder_name)
                 local main_file = path:Combine(directory, self.main_file_name)
                 if FileIO:Exists(main_file) then
-					if not self._loaded_mods[folder_name] then
+                    local do_load = not self._loaded_mods[folder_name]
+
+                    if CoreLoadingSetup then
+                        local loading_scene_file = path:Combine(directory, self.loading_scene_file_name)
+                        if not FileIO:Exists(loading_scene_file) then
+                            do_load = false
+                        end
+                    end
+
+                    if do_load then
                         self:LoadMod(folder_name, directory, main_file)
                     end
                 elseif not self._ignore_detection_errors and not self._ignored_configs[main_file] then

--- a/mod.txt
+++ b/mod.txt
@@ -10,6 +10,7 @@
 	"color" : "0 0.44 1",
 	"image" : "Assets/guis/textures/beardlib_logo.texture",
 	"hooks" : [
-		{"hook_id" : "core/lib/system/coresystem", "script_path" : "Core.lua"}
+		{"hook_id" : "core/lib/system/coresystem", "script_path" : "Core.lua"},
+		{"hook_id" : "core/lib/setups/coreloadingsetup", "script_path" : "CoreLoading.lua"}
 	]
 }


### PR DESCRIPTION
This adds a check for a specifically named file before attempting to parse/load a mod within the loading scene. This allows the new feature to be handled conditionally.

Right now the file is setup to be an extensionless named `enable_in_loading_scene` but this can be changed if so wished.
![image](https://user-images.githubusercontent.com/5340283/236915371-c208e2ba-3ba2-488a-b578-798919f8457b.png)
