### PR TITLE
Add play order option for multiple tracks in an event

### DIFF
--- a/Modules/Addons/HeistMusicModule.lua
+++ b/Modules/Addons/HeistMusicModule.lua
@@ -145,7 +145,8 @@ function HeistMusic:RegisterHook()
 			music.events[v.name] = {
 				tracks = tracks,
 				volume = v.volume or music.volume,
-				allow_switch = NotNil(v.allow_switch, music.allow_switch)
+				allow_switch = NotNil(v.allow_switch, music.allow_switch),
+				play_order = NotNil(v.play_order, music.play_order, "random")
 			}
 		end
 	end

--- a/Modules/Addons/MusicModule.lua
+++ b/Modules/Addons/MusicModule.lua
@@ -58,7 +58,8 @@ function MusicModule:RegisterHook()
 			music.events[v.name] = {
 				tracks = tracks,
 				volume = v.volume or music.volume,
-				allow_switch = NotNil(v.allow_switch, music.allow_switch)
+				allow_switch = NotNil(v.allow_switch, music.allow_switch),
+				play_order = NotNil(v.play_order, music.play_order, "random")
 			}
 		end
 	end


### PR DESCRIPTION
Current available options are "random" (default, works like previously), "shuffle" (like random but no repetition until all tracks have played), "sequence" (tracks play in sequence) and "loop" (tracks play in sequence and restart from the first one after the last one has played)