### PR TITLE
Fix custom dialogs not playing

### DIFF
--- a/Hooks/Maps/Hooks.lua
+++ b/Hooks/Maps/Hooks.lua
@@ -398,4 +398,18 @@ elseif F == "gameplaycentralmanager" then
 			unit_body:set_enabled(not unit_body:enabled())
 		end
 	end
+----------------------------------------------------------------
+elseif F == "dialogmanager" then
+	Hooks:PreHook(DialogManager, "queue_dialog", "BeardLibQueueDialogFixIds", function(self, id)
+		if id and not managers.dialog._dialog_list[id] then
+			local sound = BeardLib.Managers.Sound:GetSound(id)
+			if sound then
+				managers.dialog._dialog_list[id] = {
+					id = id,
+					sound = id,
+					priority = sound.priority and tonumber(sound.priority) or tweak_data.dialog.DEFAULT_PRIORITY
+				}
+			end
+		end
+	end)
 end

--- a/supermod.xml
+++ b/supermod.xml
@@ -75,6 +75,7 @@
                     <post hook_id="lib/managers/mission/elementvehiclespawner"/>
                     <post hook_id="lib/managers/mission/elementfilter"/>
                     <post hook_id="core/lib/managers/viewport/environment/coreenvironmentmanager"/>
+					<post hook_id="lib/managers/dialogmanager"/>
                 </group>
                 <group :script_path="NetworkHooks.lua">
                     <post hook_id="lib/managers/crimenetmanager"/>

--- a/supermod.xml
+++ b/supermod.xml
@@ -75,7 +75,7 @@
                     <post hook_id="lib/managers/mission/elementvehiclespawner"/>
                     <post hook_id="lib/managers/mission/elementfilter"/>
                     <post hook_id="core/lib/managers/viewport/environment/coreenvironmentmanager"/>
-					<post hook_id="lib/managers/dialogmanager"/>
+                    <post hook_id="lib/managers/dialogmanager"/>
                 </group>
                 <group :script_path="NetworkHooks.lua">
                     <post hook_id="lib/managers/crimenetmanager"/>


### PR DESCRIPTION
4a3d333 forgot to refactor a hook to `DialogManager:queue_dialog` that made it play custom sound IDs.