### PR TITLE
Fix prefixes_strict requiring the sound source's prefixes to be an exact match

### DIFF
--- a/Classes/Managers/SoundManager.lua
+++ b/Classes/Managers/SoundManager.lua
@@ -150,7 +150,7 @@ function BeardLibSoundManager:ComparePrefixes(data, sound_id, prefixes)
 	if data.id == sound_id then
 		if data.prefixes and prefixes then
 			if data.prefixes_strict then
-				return table.contains_all(data.prefixes, prefixes)
+				return table.contains_all(prefixes, data.prefixes)
 			else
 				return table.contains_any(data.prefixes, prefixes)
 			end


### PR DESCRIPTION
This is a simple fix for the perceived issue described in #751 

It's possible that this is not a bug, and the current behaviour is intended, but in my eyes the current functionality is of incredibly limited use whereas this change would make prefixes_strict a very useful flag, so I do think that this should be implemented in some way, even if via an additional flag.

This would likely break any mods reliant on the old behaviour, though I'm not sure if any such mods even exist.