### PR TITLE
Support loading localized soundbanks from DB

### DIFF
--- a/Classes/Managers/PackageManager.lua
+++ b/Classes/Managers/PackageManager.lua
@@ -227,7 +227,12 @@ function BeardLibPackageManager:LoadConfig(directory, config, mod, settings)
                     local dyn_load_menu = NotNil(child.load_in_menu, config.load_in_menu, false)
                     local dyn_load = NotNil(child.load, config.load, false)
 
-                    if (from_db and blt.asset_db.has_file(path, typ)) or (not from_db and FileIO:Exists(file_path_ext)) then
+                    local language
+                    if typ == "bnk" and from_db and not blt.asset_db.has_file(path, typ) then 
+                        language = "english" -- has_file requires language for localized soundbanks. As of U240.6, base game soundbanks are only in english.
+                    end
+
+                    if (from_db and blt.asset_db.has_file(path, typ, language and {language = language})) or (not from_db and FileIO:Exists(file_path_ext)) then
                         local load = force
                         if not load then
                             local force_if_not_loaded = NotNil(child.force_if_not_loaded, config.force_if_not_loaded, false)


### PR DESCRIPTION
Currently BeardLib can only load soundbanks with no language variations as `blt.asset_db.has_file` returns false because of the missing language specification.  This will provide it when 1. asset is "bnk", 2. asset is from_db and 3. `has_file` would fail without the language.

Also of note is that soundbanks require `load="true"`.