### PR TITLE
Don't warn in logs unless devmode is enabled

### DIFF
--- a/Classes/ModCore.lua
+++ b/Classes/ModCore.lua
@@ -232,7 +232,9 @@ function ModCore:LogErr(str, ...)
 end
 
 function ModCore:Warn(str, ...)
-    log("[" .. self.Name .. "][WARN] " .. string.format(str, ...))
+	if BeardLib.DevMode then
+		log("[" .. self.Name .. "][WARN] " .. string.format(str, ...))
+	end
 end
 
 function ModCore:StringToValue(str)


### PR DESCRIPTION
Like in the title, I have never seen a [WARN] when using BeardLib normally for many years but recently I've come across a problem which can only be solved by changing BeardLib itself. 

This problem is trying to achieve synced environments with a mod across all players in a lobby if the said mod has multiple different environments for a single heist that can appear at random every time you play. The sync itself works perfectly but there is a huge log spam if someone tries to join the game mid-heist due to how many times the peer tries to sync the entire game multiple times.
Log spam can slow down the game to a crawl or even outright freeze it sometimes, as well as make logs reach more than 10 mb in size after just 3 heists of play.

This can only be fixed by suppressing warnings (and I already have on my side alongside a few others) but it makes it impossible to even think of publishing these environments with sync code despite all the work that went into it, so I really hope that this PR may at least be considered being implemented as most users likely don't even run devmode unless they are actually working on intricate mods or maps. 🙏