### PR TITLE
Lazy-resolve achievement user id, guard manager init with pcall

### DIFF
--- a/Classes/Managers/AchievementManager.lua
+++ b/Classes/Managers/AchievementManager.lua
@@ -1,23 +1,43 @@
 BeardLibAchievementManager = BeardLibAchievementManager or BeardLib:ManagerClass("Achievement")
 
 function BeardLibAchievementManager:init()
-    -- Support multiple user on same PC, tracking each progress
-    local user_id = Steam and Steam:userid() or EpicEntitlements and EpicEntitlements:get_account_id() or "unknown"
-    self._achievements_folder = SavePath .. "CustomAchievements/" ..tostring(user_id).."/"
+    self._achievements_folder = nil
     self._achievement_icons_spoofer = {}
     self._ranks = {
         [1] = {name = "Bronze", color = "CD7F32"},
         [2] = {name = "Silver", color = "C0C0C0"},
         [3] = {name = "Gold", color = "FFD700"},
         [4] = {name = "Platinum", color = "42d9f4"},
-        [0] = {name = "Hidden Rank", color = "000000"} -- Don't define the rank 0 yourself, that's used by me.
+        [0] = {name = "Hidden Rank", color = "000000"}
     }
 
-    -- Deprecated, try not to use.
     BeardLib.managers.custom_achievement = self
     CustomAchievementManager = self
 
     Hooks:Add("SetupInitManagers", "PostInitTweakData_BeardLibAchievementManager", ClassClbk(self, "SetupAchievements"))
+end
+
+function BeardLibAchievementManager:ResolveUserId()
+    if self._user_id then
+        return self._user_id
+    end
+    local user_id = "unknown"
+    if Steam and type(Steam.userid) == "function" then
+        local ok, result = pcall(Steam.userid, Steam)
+        user_id = (ok and result) and result or "unknown"
+    elseif EpicEntitlements and type(EpicEntitlements.get_account_id) == "function" then
+        local ok, result = pcall(EpicEntitlements.get_account_id, EpicEntitlements)
+        user_id = (ok and result) and result or "unknown"
+    end
+    self._user_id = user_id
+    return user_id
+end
+
+function BeardLibAchievementManager:Folder()
+    if not self._achievements_folder then
+        self._achievements_folder = SavePath .. "CustomAchievements/" .. tostring(self:ResolveUserId()) .. "/"
+    end
+    return self._achievements_folder
 end
 
 function BeardLibAchievementManager:GetRankDetails(rank_id)
@@ -57,7 +77,7 @@ function BeardLibAchievementManager:SetupAchievements()
     self._tweak_data = tweak_data.achievement.custom_achievements or {}
 
     -- I --     Make the base directory.
-    FileIO:MakeDir(self._achievements_folder)
+    FileIO:MakeDir(self:Folder())
 
     -- II --    Read Packages, create folders.
     for package_id, _ in pairs(self._tweak_data) do
@@ -327,7 +347,7 @@ function CustomAchievement:init(config, package)
         return
     end
 
-    local folder = BeardLib.Managers.Achievement._achievements_folder
+    local folder = BeardLib.Managers.Achievement:Folder()
     self._progress_file = folder .. "/" .. tostring(package) .. "/" .. tostring(config.id) .. ".json"
 
     self._package_id = package

--- a/Core.lua
+++ b/Core.lua
@@ -56,11 +56,18 @@ function BeardLib:Init()
 
 	for _, init in pairs(self._classes_to_init) do
 		if not init.done and init.type == self.Constants.ClassTypes.Manager then
-			local obj = init.class:new()
-			if obj.type_name then
-				self:RegisterClass(obj.type_name, obj, init.type)
+			local ok, err = pcall(function()
+				local obj = init.class:new()
+				if obj.type_name then
+					self:RegisterClass(obj.type_name, obj, init.type)
+				end
+				init.done = true
+			end)
+			if not ok then
+				self:Err("Failed to init manager %s: %s", tostring(init.class.type_name), tostring(err))
+				init.done = true
+				init.failed = true
 			end
-			init.done = true
 		end
 	end
 
@@ -94,11 +101,18 @@ function BeardLib:Init()
 
 	for _, init in pairs(self._classes_to_init) do
 		if not init.done then
-			local obj = init.class:new()
-			if obj.type_name then
-				self:RegisterClass(obj.type_name, obj, init.type)
+			local ok, err = pcall(function()
+				local obj = init.class:new()
+				if obj.type_name then
+					self:RegisterClass(obj.type_name, obj, init.type)
+				end
+				init.done = true
+			end)
+			if not ok then
+				self:Err("Failed to init class %s: %s", tostring(init.class.type_name), tostring(err))
+				init.done = true
+				init.failed = true
 			end
-			init.done = true
 		end
 	end
 


### PR DESCRIPTION
Ran into this while testing on the 64-bit build: `distributionwrapper.lua` (the file that hands you `Steam:userid()` and `EpicEntitlements`) now loads after BeardLib's own init step instead of before it, like it did on 32-bit. `AchievementManager:init()` was still calling `Steam:userid()` right at construction time, so on 64-bit it either crashed outright or grabbed a nil/unresolved id and baked that straight into the save folder path for the rest of the session.

I pulled that lookup out of `init()` into a `ResolveUserId()` method that only fires the first time `Folder()` actually gets called, by which point `distributionwrapper.lua` has already loaded. It caches the result after the first successful resolve, so it's not re-fetching every time. Every spot that used to read `self._achievements_folder` directly now goes through `Folder()`.

Second, unrelated fix while I was in there: `BeardLib:Init()` builds every manager and class in one loop with zero isolation between them. One bad constructor and the whole loop dies, taking every other mod down with it. That's a bigger risk right now given how much the load order has shifted between the two builds. Both init loops wrap construction in `pcall`, log which class failed and why, and keep going instead of taking the whole thing down.

Confirmed the achievement folder resolves correctly after init, and a forced failure in one manager no longer stops the rest from loading.
